### PR TITLE
feat(account-card): add account card component to fetch account balance

### DIFF
--- a/src/components/app/AccountCard.test.tsx
+++ b/src/components/app/AccountCard.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { mockAuthUser, mockFirestore, render } from 'testUtils';
+import AccountCard from './AccountCard';
+
+const TEST_ACCOUNT = {
+  id: 3,
+  name: 'Test Account',
+  type: 'normal' as const,
+  currency: 'gbp' as const,
+};
+const TEST_USER_ID = 'test-user-id';
+
+test('render account information', () => {
+  const { getByText } = render(<AccountCard account={TEST_ACCOUNT} />, {
+    userAndSettings: true,
+  });
+
+  act(() => void mockAuthUser({ uid: TEST_USER_ID }));
+  act(() =>
+    mockFirestore(`users/${TEST_USER_ID}/accounts/${TEST_ACCOUNT.id}`, {
+      balance: 55.5,
+    })
+  );
+
+  expect(getByText(TEST_ACCOUNT.name)).toBeInTheDocument();
+  expect(getByText('Normal Account')).toBeInTheDocument();
+  expect(getByText('£')).toBeInTheDocument();
+  expect(getByText('55')).toBeInTheDocument();
+  expect(getByText('.')).toBeInTheDocument();
+  expect(getByText('50')).toBeInTheDocument();
+});
+
+test('balance should be zero when no data exist', () => {
+  const { getByText } = render(<AccountCard account={TEST_ACCOUNT} />, {
+    userAndSettings: true,
+  });
+
+  act(() => void mockAuthUser({ uid: TEST_USER_ID }));
+  act(() =>
+    mockFirestore(`users/${TEST_USER_ID}/accounts/${TEST_ACCOUNT.id}`, null)
+  );
+
+  expect(getByText('£')).toBeInTheDocument();
+  expect(getByText('0')).toBeInTheDocument();
+  expect(getByText('.')).toBeInTheDocument();
+  expect(getByText('00')).toBeInTheDocument();
+});

--- a/src/components/app/AccountCard.tsx
+++ b/src/components/app/AccountCard.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from '@material-ui/core';
+import { firestore } from 'firebase/app';
+import Currency from 'components/base/Currency';
+import useTexts from 'hooks/useTexts';
+import user from 'stores/user';
+
+function AccountCard({
+  className,
+  account,
+}: {
+  className?: string;
+  account: Settings.Account;
+}) {
+  const { id, type, name, currency } = account;
+  const [t] = useTexts();
+  const [{ uid }] = user.useStore();
+  const [balance, setBalance] = useState(0);
+
+  useEffect(() => {
+    const db = firestore();
+    db.doc(`users/${uid}/accounts/${id}`).onSnapshot((doc) => {
+      const data = doc.data();
+      if (data && 'balance' in data) {
+        setBalance(data.balance);
+      }
+    });
+  }, [id, uid]);
+
+  return (
+    <Card className={className} elevation={4}>
+      <CardActionArea>
+        <CardContent>
+          <Typography color="textSecondary" variant="subtitle1">
+            {type === 'debt' ? t.ACCOUNT_TYPE_DEBT : t.ACCOUNT_TYPE_NORMAL}
+          </Typography>
+          <Typography>{name}</Typography>
+
+          <Currency
+            align="right"
+            currency={currency.toUpperCase()}
+            value={balance}
+            variant={['h6', 'subtitle1']}
+          />
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+export default AccountCard;

--- a/src/components/views/Dashboard.tsx
+++ b/src/components/views/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
 import { Add } from '@material-ui/icons';
 import Currency from 'components/base/Currency';
 import TopNav from 'components/app/TopNav';
+import AccountCard from 'components/app/AccountCard';
 import useTexts from 'hooks/useTexts';
 import useModalHash, { Modal } from 'hooks/useModalHash';
 import settings from 'stores/settings';
@@ -97,32 +98,17 @@ function Dashboard() {
           cols={1.5}
           spacing={16}
         >
-          {accounts.map(({ id, name, type, currency }) => (
+          {accounts.map((account) => (
             <GridListTile
-              key={`dashboard-account-${id}`}
+              key={`dashboard-account-${account.id}`}
               classes={{
                 tile: classes.gridListTile,
               }}
             >
-              <Card className={classes.gridAddButton} elevation={4}>
-                <CardActionArea>
-                  <CardContent>
-                    <Typography color="textSecondary" variant="subtitle1">
-                      {type === 'debt'
-                        ? t.ACCOUNT_TYPE_DEBT
-                        : t.ACCOUNT_TYPE_NORMAL}
-                    </Typography>
-                    <Typography>{name}</Typography>
-
-                    <Currency
-                      align="right"
-                      currency={currency.toUpperCase()}
-                      value={1234.56}
-                      variant={['h6', 'subtitle1']}
-                    />
-                  </CardContent>
-                </CardActionArea>
-              </Card>
+              <AccountCard
+                account={account}
+                className={classes.gridAddButton}
+              />
             </GridListTile>
           ))}
           <GridListTile


### PR DESCRIPTION
Sets up a snapshot listener for account balance and show it inside the new AccountCard component.

fix #420